### PR TITLE
Fix Friend yielding list

### DIFF
--- a/Timeline/Handlers/Friends.py
+++ b/Timeline/Handlers/Friends.py
@@ -138,8 +138,8 @@ AS2 and AS3 Compatible
 def handleRemoveFriend(client, data):
     swid = data[2][0]
 
-    friend = yield Friend.find(where=['penguin_swid = ? AND friend = ?', swid, client['swid']])
-    me = yield Friend.find(where=['penguin_swid = ? AND friend = ?', client['swid'], swid])
+    friend = yield Friend.find(where=['penguin_swid = ? AND friend = ?', swid, client['swid']], limit=1)
+    me = yield Friend.find(where=['penguin_swid = ? AND friend = ?', client['swid'], swid], limit=1)
 
     friend.delete() if friend is not None else 0
     me.delete() if me is not None else 0


### PR DESCRIPTION
This fix prevents "handleRemoveFriend : 'list' object has no attribute 'delete'" by requesting only one row, which won't return a list.
